### PR TITLE
Fix problem sharing the inventory

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'com.android.support:support-v4:27.1.1'
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support:design:27.1.1'
-    implementation 'org.flyve:inventory:0.8.5@aar'
+    implementation 'org.flyve:inventory:0.8.6@aar'
     implementation 'com.bugsnag:bugsnag-android:4.1.3'
     implementation 'com.orhanobut:logger:2.1.1'
     implementation 'com.android.support:multidex:1.0.2'

--- a/app/release/output.json
+++ b/app/release/output.json
@@ -1,1 +1,1 @@
-[{"outputType":{"type":"APK"},"apkInfo":{"type":"MAIN","splits":[],"versionCode":37960},"path":"app-release.apk","properties":{"packageId":"org.flyve.inventory.agent","split":"","minSdkVersion":"16"}}]
+[{"outputType":{"type":"APK"},"apkInfo":{"type":"MAIN","splits":[],"versionCode":1582},"path":"app-release.apk","properties":{"packageId":"org.flyve.inventory.agent","split":"","minSdkVersion":"16"}}]

--- a/app/src/main/java/org/flyve/inventory/agent/core/splash/SplashModel.java
+++ b/app/src/main/java/org/flyve/inventory/agent/core/splash/SplashModel.java
@@ -26,6 +26,7 @@ package org.flyve.inventory.agent.core.splash;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Handler;
+
 import org.flyve.inventory.agent.utils.FlyveLog;
 import org.flyve.inventory.agent.utils.Helpers;
 import org.flyve.inventory.agent.utils.LocalStorage;
@@ -62,7 +63,9 @@ public class SplashModel implements Splash.Model {
             new Handler().postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    Helpers.openActivity(activity, classToOpen, true);
+                    if(!activity.isFinishing()) {
+                        Helpers.openActivity(activity, classToOpen, true);
+                    }
                 }
             }, delay);
         } catch (Exception ex) {

--- a/app/src/main/java/org/flyve/inventory/agent/utils/Helpers.java
+++ b/app/src/main/java/org/flyve/inventory/agent/utils/Helpers.java
@@ -155,16 +155,19 @@ public class Helpers {
         notificationManager.notify(121, builder.build());
     }
 
-    public static void share(Context context, String message, int type){
-        Intent intent = new Intent(Intent.ACTION_SEND);
-        intent.setType("text/plain");
-        intent.putExtra(Intent.EXTRA_TEXT, message);
-        if(type==1) {
-            intent.putExtra(Intent.EXTRA_STREAM, Uri.parse("file:///sdcard/FlyveMDM/Inventory.json"));
-        } else {
-            intent.putExtra(Intent.EXTRA_STREAM, Uri.parse("file:///sdcard/FlyveMDM/Inventory.xml"));
-        }
-        context.startActivity(Intent.createChooser(intent, "Share your inventory"));
+    public static void share(Context context, String message, final int type){
+        final InventoryTask inventoryTask = new InventoryTask(context, "", true);
+        inventoryTask.getXML(new InventoryTask.OnTaskCompleted() {
+            @Override
+            public void onTaskSuccess(String s) {
+                inventoryTask.shareInventory(type);
+            }
+
+            @Override
+            public void onTaskError(Throwable throwable) {
+                FlyveLog.e(throwable.getMessage());
+            }
+        });
     }
 
     public static String capitalize(String str) {


### PR DESCRIPTION
### Changes description

<!-- Describe results, user mentions, screenshots, screencast (gif) -->
- When the agent share the inventory on Android 6.0 show a message that say "incompatible format" now the agent is using the share method from the library

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@rafaelje|6|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes: https://github.com/flyve-mdm/android-inventory-agent/issues/165
Related #N/A
Depends on #N/A