### PR TITLE
Add languages in Transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 minimum_perc = 80
-lang_map = pt_BR: pt-rBR, ru_RU: ru-rRU, fr_FR: fr-rFR, es_MX: es-rMX, es_ES: es-rES, en_GB: en-rGB, ko_KR: ko-rKR, ar_EG: ar-rEG, cs_CZ: cs-rCZ, he_IL: he-rIL, ar_SA: ar-rSA, ca_ES: ca-rES
+lang_map = pt_BR: pt-rBR, ru_RU: ru-rRU, fr_FR: fr-rFR, es_MX: es-rMX, es_ES: es-rES, en_GB: en-rGB, ko_KR: ko-rKR, ar_EG: ar-rEG, cs_CZ: cs-rCZ, he_IL: he-rIL, ar_SA: ar-rSA, ca_ES: ca-rES, zh_CN: zh-rCN, nl_NL: nl-rNL, fr: fr, gl_ES: gl-rES, de_DE: de-rDE, hi_IN: hi-rIN, hu_Hu: hu-rHU, it_IT: it-rIT, ja: ja, ja_JP: ja-rJP, pl_PL: pl-rPL, es: es, es_AR: es-rAR, th_TH: th-rTH, ur_PK: ur-rPK
 
 [android-inventory-agent.stringsxml-android]
 file_filter = app/src/main/res/values-<lang>/strings.xml


### PR DESCRIPTION
Signed-off-by: Ivan Del Pino <idelpino@teclib.com>

### Changes description

Added languages:
zh_CN: zh-rCN, nl_NL: nl-rNL, fr: fr, gl_ES: gl-rES, de_DE: de-rDE, hi_IN: hi-rIN, hu_Hu: hu-rHU, it_IT: it-rIT, ja: ja, ja_JP: ja-rJP, pl_PL: pl-rPL, es: es, es_AR: es-rAR, th_TH: th-rTH, ur_PK: ur-rPK

Languages in transifex
https://www.transifex.com/flyve-mdm/android-inventory-agent/languages/

### Checklist

Please check if your PR fulfills the following specifications:

- [x] Tests for the changes have been added
- [ ] Docs have been added/updated

### Estimated time

<!-- Add the number of pomodoros spent on this task -->

|Assignee|:tomato:|
|:---|:---:|
|@ivans51|1|

<!--- Task not finished? Please give an update of the time --->

### References

<!-- issues related (for reference or to be closed), dependencies and/or links of discuss -->

Closes #N/A
Related #N/A
Depends on #N/A